### PR TITLE
Feat/#52

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$/findex" />
+  </component>
   <component name="ProjectRootManager">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,9 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/findex.iml" filepath="$PROJECT_DIR$/.idea/modules/findex.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/findex.main.iml" filepath="$PROJECT_DIR$/.idea/modules/findex.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/findex.test.iml" filepath="$PROJECT_DIR$/.idea/modules/findex.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/sb01-findex-team8.iml" filepath="$PROJECT_DIR$/.idea/sb01-findex-team8.iml" />
     </modules>
   </component>

--- a/findex/src/main/java/com/example/findex/api/IndexDataApi.java
+++ b/findex/src/main/java/com/example/findex/api/IndexDataApi.java
@@ -179,11 +179,11 @@ public interface IndexDataApi {
       @ApiResponse(responseCode = "200", description = "지수 성과 랭킹 조회 성공", content = @Content(schema = @Schema(implementation = RankedIndexPerformanceDto.class))),
       @ApiResponse(responseCode = "400", description = "잘못된 요청")})
   ResponseEntity<List<RankedIndexPerformanceDto>> getIndexPerformanceRank(
-      @Parameter(description = "기간 타입 (DAILY, WEEKLY, MONTHLY)", required = true, example = "DAILY") @RequestParam String periodType,
+      @Parameter(description = "기간 타입 (DAILY, WEEKLY, MONTHLY)", required = false, example = "DAILY") @RequestParam String periodType,
 
-      @Parameter(description = "지수 정보 ID", required = true, example = "1") @RequestParam int indexInfoId,
+      @Parameter(description = "지수 정보 ID", required = false, example = "1") @RequestParam Integer indexInfoId,
 
-      @Parameter(description = "조회할 최대 개수", required = true, example = "10") @RequestParam int limit
+      @Parameter(description = "조회할 최대 개수", required = false, example = "10") @RequestParam Integer limit
   );
 
   @Operation(summary = "지수 데이터 CSV 다운로드", description = "지수 데이터를 CSV 파일로 다운로드합니다.")
@@ -215,6 +215,6 @@ public interface IndexDataApi {
     })
     ResponseEntity<IndexChartDto> getIndexChart(
             @PathVariable @Parameter(description = "지수 정보 ID", example = "1") int indexInfoId,
-            @RequestParam @Parameter(description = "조회 기간 타입 (예: daily, weekly, monthly)", example = "daily") String periodType
+            @RequestParam @Parameter(description = "조회 기간 타입 (예: daily, weekly, monthly)", required = false, example = "daily") String periodType
     );
 }

--- a/findex/src/main/java/com/example/findex/controller/IndexDataController.java
+++ b/findex/src/main/java/com/example/findex/controller/IndexDataController.java
@@ -36,12 +36,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class IndexDataController implements IndexDataApi {
 
   private final IndexDataService indexDataService;
-  private final IndexInfoService indexInfoService;
 
   @Override
   @GetMapping("/performance/favorite")
   public ResponseEntity<List<IndexPerformanceDto>> getIndexFavoritePerformanceRank(
-      @RequestParam String periodType
+      @RequestParam(required = false, defaultValue = "DAILY") String periodType
   ){
     List<IndexPerformanceDto> dto = indexDataService.getInterestIndexPerformance(periodType);
     return ResponseEntity.status(HttpStatus.OK).body(dto);
@@ -50,9 +49,9 @@ public class IndexDataController implements IndexDataApi {
   @Override
   @GetMapping("/performance/rank")
   public ResponseEntity<List<RankedIndexPerformanceDto>> getIndexPerformanceRank(
-      @RequestParam String periodType,
-      @RequestParam int indexInfoId,
-      @RequestParam int limit) {
+      @RequestParam(required = false, defaultValue = "DAILY") String periodType,
+      @RequestParam(required = false) Integer indexInfoId,
+      @RequestParam(required = false, defaultValue = "10") Integer limit) {
     List<RankedIndexPerformanceDto> dto = indexDataService.getIndexPerformanceRank(periodType, indexInfoId, limit);
     return ResponseEntity.status(HttpStatus.OK).body(dto);
   }
@@ -61,7 +60,7 @@ public class IndexDataController implements IndexDataApi {
   @GetMapping("/{indexInfoId}/chart")
   public ResponseEntity<IndexChartDto> getIndexChart(
       @PathVariable int indexInfoId,
-      @RequestParam String periodType
+      @RequestParam(required = false, defaultValue = "DAILY")  String periodType
   ) {
     IndexChartDto dto = indexDataService.getIndexChart(periodType, indexInfoId);
     return ResponseEntity.status(HttpStatus.OK).body(dto);

--- a/findex/src/main/java/com/example/findex/repository/IndexDataRepositoryCustom.java
+++ b/findex/src/main/java/com/example/findex/repository/IndexDataRepositoryCustom.java
@@ -13,4 +13,10 @@ public interface IndexDataRepositoryCustom {
       Long indexInfoId, LocalDate startDate, LocalDate endDate, String sortField,
       String sortDirection
   );
+
+  List<IndexData> findByFiltersWithQueryDSL(
+      Long indexInfoId, LocalDate startDate,
+      LocalDate endDate, String sortField,
+      String sortDirection
+  );
 }

--- a/findex/src/main/java/com/example/findex/service/IndexDataService.java
+++ b/findex/src/main/java/com/example/findex/service/IndexDataService.java
@@ -291,7 +291,7 @@ public class IndexDataService {
       Long indexInfoId, LocalDate startDate, LocalDate endDate,
       String sortField, String sortDirection
   ) {
-    return indexDataRepository.findByFilters(
+    return indexDataRepository.findByFiltersWithQueryDSL(
         indexInfoId, startDate, endDate, sortField, sortDirection);
   }
 


### PR DESCRIPTION
## 작업 내용

- `"/performance/rank"`의 param들을 nullable하게 변경
- indexInfoId가 null이거나 음수일 경우 모든 데이터를 가져오게 변경
- CSV 다운로드에서 사용하는 findByFilters를 querydsl로 변경
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #52

<br><br>
